### PR TITLE
Fix: Correct NIC configuration for StHelens.

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-opp-sthelens.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-sthelens.dts
@@ -11,11 +11,14 @@
                         compatible = "faraday,ftgmac100", "aspeed,ast2400-mac";
                         reg = <0x1e660000 0x180>;
                         interrupts = <2>;
+                        no-hw-checksum;
+                        status = "disabled";
                 };
 
                 mac1: ethernet@1e680000 {
                         compatible = "faraday,ftgmac100", "aspeed,ast2400-mac";
                         reg = <0x1e680000 0x180>;
+                        no-hw-checksum;
                         interrupts = <3>;
                 };
 


### PR DESCRIPTION
For st-helens delicated nic, we should config it as no-hw-checksum.

Signed-off-by: SteveLinCH <dreamerch999@gmail.com>